### PR TITLE
Fix required attributes

### DIFF
--- a/backend/migrations/1_init.up.psql
+++ b/backend/migrations/1_init.up.psql
@@ -275,7 +275,7 @@ BEGIN
 
     -- Проверка на обязательность значения
     IF value_required = true THEN
-      IF (type_attribute = 'text'::attribute_type AND NEW.value_text IS NULL)
+      IF (type_attribute = 'text'::attribute_type AND NEW.value_text ='')
        OR (type_attribute = 'boolean'::attribute_type AND NEW.value_boolean IS NULL)
        OR (type_attribute = 'number'::attribute_type AND NEW.value_number IS NULL)
       THEN


### PR DESCRIPTION
Пофиксил для текстовых атрибутов 
Для численных - ставится 0, если пустое, так что скип
Для була - тем более